### PR TITLE
Hide updated age for static crawler records

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -126,7 +126,7 @@
             </table>
             <p v-if="!(event.fajrIqama || event.juma1)">Check website for prayer times.</p>
             <p v-if="event.diffTz" class="text-warning">Note: This masjid may be in a a different time zone</p>
-            <small v-bind:class="{ 'text-danger': event.stale }">
+            <small v-if="event.showUpdatedLabel" v-bind:class="{ 'text-danger': event.stale }">
               last updated {{ event.updatedLabel }} ago<br>
             </small>
           </div>
@@ -170,4 +170,3 @@
 </body>
 
 </html>
-

--- a/src/index.js
+++ b/src/index.js
@@ -419,6 +419,11 @@ window.getCurrentPosition = getCurrentPosition
 
 function docToEvent (doc) {
   const evt = doc.data()
+  const crawlTime = (
+    evt.crawlTime && typeof evt.crawlTime.toDate === 'function'
+      ? evt.crawlTime.toDate()
+      : (evt.crawlTime instanceof Date ? evt.crawlTime : null)
+  )
 
   const times = SunCalc.getTimes(now, evt.geo.latitude, evt.geo.longitude)
   const fcmTopic = '/topics/' + doc.id
@@ -441,8 +446,9 @@ function docToEvent (doc) {
     juma1IsModified: (evt.juma1Modified && hoursSince(evt.juma1Modified.toDate()) < 24),
     juma2IsModified: (evt.juma2Modified && hoursSince(evt.juma2Modified.toDate()) < 24),
     juma3IsModified: (evt.juma3Modified && hoursSince(evt.juma3Modified.toDate()) < 24),
-    updatedLabel: timeSince(evt.crawlTime.toDate()),
-    stale: (hoursSince(evt.crawlTime.toDate()) > 12)
+    showUpdatedLabel: (!evt.isStatic && Boolean(crawlTime)),
+    updatedLabel: crawlTime ? timeSince(crawlTime) : '',
+    stale: (crawlTime ? (hoursSince(crawlTime) > 12) : false)
   }, evt)
   return merged
 }


### PR DESCRIPTION
## Summary
- hide the "last updated … ago" line when an Event document is marked `isStatic`
- keep the label for dynamic records and legacy docs that do not yet have the new flag
- make `crawlTime` handling explicit before deriving the display fields

## Dependency
- depends on praytime/praytime#76 to populate `Events.isStatic`

## Testing
- npm run build